### PR TITLE
Fix release archive contents

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Publish
         run: |
-          dotnet publish qatch.csproj -c Release -o ./publish --no-build --nologo
-          find ./publish -name "*.pdb" -type f -delete
+          dotnet publish qatch.csproj -c Release -o ./ --no-build --nologo
+          find ./ -name "*.pdb" -type f -delete
 
       - name: Create versioned archive
         run: |
           VERSION=$(grep -oP '<Version>\K[^<]+' qatch.csproj)
-          zip -r qatch-v$VERSION.zip ./publish/*
+          zip -r qatch-v$VERSION.zip ./*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #1

Update `.github/workflows/build-and-release.yml` to remove unnecessary subfolder in release archive.

* Change the `dotnet publish` command to specify the output directory as `./` instead of `./publish`.
* Change the `zip` command to include the contents of the root directory in the archive instead of `./publish/*`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itsalfredakku/qatch/pull/2?shareId=9bbe839e-78e1-4c57-9348-27b16e940bc5).